### PR TITLE
Support an optional user ID everywhere

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ uv run ruff check            # Run linting
 uv run ruff format           # Format code
 uv run pytest                # Run tests
 uv run pytest tests/         # Run specific test directory
+uv run pytest --run-api-tests # Run all tests, including API tests
 uv add <dependency>          # Add a dependency to pyproject.toml and update lock file
 uv remove <dependency>       # Remove a dependency from pyproject.toml and update lock file
 

--- a/agent-memory-client/README.md
+++ b/agent-memory-client/README.md
@@ -206,8 +206,8 @@ await client.update_working_memory_data(
 
 # Append messages
 new_messages = [
-    MemoryMessage(role="user", content="What's the weather?"),
-    MemoryMessage(role="assistant", content="It's sunny today!")
+    {"role": "user", "content": "What's the weather?"},
+    {"role": "assistant", "content": "It's sunny today!"}
 ]
 
 await client.append_messages_to_working_memory(

--- a/agent-memory-client/agent_memory_client/__init__.py
+++ b/agent-memory-client/agent_memory_client/__init__.py
@@ -5,7 +5,7 @@ A Python client for the Agent Memory Server REST API providing comprehensive
 memory management capabilities for AI agents and applications.
 """
 
-__version__ = "0.9.0b3"
+__version__ = "0.9.0b4"
 
 from .client import MemoryAPIClient, MemoryClientConfig, create_memory_client
 from .exceptions import (

--- a/agent-memory-client/tests/test_client.py
+++ b/agent-memory-client/tests/test_client.py
@@ -527,8 +527,8 @@ class TestEnhancedConvenienceMethods:
         )
 
         new_messages = [
-            MemoryMessage(role="assistant", content="Second message"),
-            MemoryMessage(role="user", content="Third message"),
+            {"role": "assistant", "content": "Second message"},
+            {"role": "user", "content": "Third message"},
         ]
 
         with (

--- a/agent_memory_server/__init__.py
+++ b/agent_memory_server/__init__.py
@@ -1,3 +1,3 @@
 """Redis Agent Memory Server - A memory system for conversational AI."""
 
-__version__ = "0.9.0b3"
+__version__ = "0.9.0b4"

--- a/agent_memory_server/api.py
+++ b/agent_memory_server/api.py
@@ -188,7 +188,7 @@ async def list_sessions(
     Get a list of session IDs, with optional pagination.
 
     Args:
-        options: Query parameters (page, size, namespace)
+        options: Query parameters (limit, offset, namespace, user_id)
 
     Returns:
         List of session IDs
@@ -200,6 +200,7 @@ async def list_sessions(
         limit=options.limit,
         offset=options.offset,
         namespace=options.namespace,
+        user_id=options.user_id,
     )
 
     return SessionListResponse(
@@ -211,8 +212,8 @@ async def list_sessions(
 @router.get("/v1/working-memory/{session_id}", response_model=WorkingMemoryResponse)
 async def get_working_memory(
     session_id: str,
+    user_id: str | None = None,
     namespace: str | None = None,
-    window_size: int = settings.window_size,  # Deprecated: kept for backward compatibility
     model_name: ModelNameLiteral | None = None,
     context_window_max: int | None = None,
     current_user: UserInfo = Depends(get_current_user),
@@ -225,8 +226,8 @@ async def get_working_memory(
 
     Args:
         session_id: The session ID
+        user_id: The user ID to retrieve working memory for
         namespace: The namespace to use for the session
-        window_size: DEPRECATED - The number of messages to include (kept for backward compatibility)
         model_name: The client's LLM model name (will determine context window size if provided)
         context_window_max: Direct specification of the context window max tokens (overrides model_name)
 
@@ -240,6 +241,7 @@ async def get_working_memory(
         session_id=session_id,
         namespace=namespace,
         redis_client=redis,
+        user_id=user_id,
     )
 
     if not working_mem:
@@ -249,6 +251,7 @@ async def get_working_memory(
             memories=[],
             session_id=session_id,
             namespace=namespace,
+            user_id=user_id,
         )
 
     # Apply token-based truncation if we have messages and model info
@@ -266,10 +269,6 @@ async def get_working_memory(
                     break
             working_mem.messages = truncated_messages
 
-    # Fallback to message-count truncation for backward compatibility
-    elif len(working_mem.messages) > window_size:
-        working_mem.messages = working_mem.messages[-window_size:]
-
     return working_mem
 
 
@@ -277,6 +276,7 @@ async def get_working_memory(
 async def put_working_memory(
     session_id: str,
     memory: WorkingMemory,
+    user_id: str | None = None,
     model_name: ModelNameLiteral | None = None,
     context_window_max: int | None = None,
     background_tasks=Depends(get_background_tasks),
@@ -291,6 +291,7 @@ async def put_working_memory(
     Args:
         session_id: The session ID
         memory: Working memory to save
+        user_id: Optional user ID for the session (overrides user_id in memory object)
         model_name: The client's LLM model name for context window determination
         context_window_max: Direct specification of context window max tokens
         background_tasks: DocketBackgroundTasks instance (injected automatically)
@@ -302,6 +303,10 @@ async def put_working_memory(
 
     # Ensure session_id matches
     memory.session_id = session_id
+
+    # Override user_id if provided as query parameter
+    if user_id is not None:
+        memory.user_id = user_id
 
     # Validate that all structured memories have id (if any)
     for mem in memory.memories:
@@ -359,6 +364,7 @@ async def put_working_memory(
 @router.delete("/v1/working-memory/{session_id}", response_model=AckResponse)
 async def delete_working_memory(
     session_id: str,
+    user_id: str | None = None,
     namespace: str | None = None,
     current_user: UserInfo = Depends(get_current_user),
 ):
@@ -369,6 +375,7 @@ async def delete_working_memory(
 
     Args:
         session_id: The session ID
+        user_id: Optional user ID for the session
         namespace: Optional namespace for the session
 
     Returns:
@@ -379,6 +386,7 @@ async def delete_working_memory(
     # Delete unified working memory
     await working_memory.delete_working_memory(
         session_id=session_id,
+        user_id=user_id,
         namespace=namespace,
         redis_client=redis,
     )
@@ -558,6 +566,7 @@ async def memory_prompt(
         working_mem = await working_memory.get_working_memory(
             session_id=params.session.session_id,
             namespace=params.session.namespace,
+            user_id=params.session.user_id,
             redis_client=redis,
         )
 

--- a/agent_memory_server/config.py
+++ b/agent_memory_server/config.py
@@ -20,7 +20,6 @@ def load_yaml_settings():
 class Settings(BaseSettings):
     redis_url: str = "redis://localhost:6379"
     long_term_memory: bool = True
-    window_size: int = 20
     openai_api_key: str | None = None
     anthropic_api_key: str | None = None
     generation_model: str = "gpt-4o-mini"
@@ -65,6 +64,9 @@ class Settings(BaseSettings):
     # Auth0 Client Credentials (for testing and client applications)
     auth0_client_id: str | None = None
     auth0_client_secret: str | None = None
+
+    # Working memory settings
+    window_size: int = 20  # Default number of recent messages to return
 
     # Other Application settings
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"

--- a/agent_memory_server/long_term_memory.py
+++ b/agent_memory_server/long_term_memory.py
@@ -46,9 +46,6 @@ from agent_memory_server.utils.redis import (
 )
 
 
-DEFAULT_MEMORY_LIMIT = 1000
-MEMORY_INDEX = "memory_idx"
-
 # Prompt for extracting memories from messages in working memory context
 WORKING_MEMORY_EXTRACTION_PROMPT = """
 You are a memory extraction assistant. Your job is to analyze conversation
@@ -354,15 +351,27 @@ async def compact_long_term_memories(
                         # Find all memories with this hash
                         # Use FT.SEARCH to find the actual memories with this hash
                         # TODO: Use RedisVL index
-                        search_query = (
-                            f"FT.SEARCH {index_name} "
-                            f"(@memory_hash:{{{memory_hash}}}) {' '.join(filters)} "
-                            "RETURN 6 id_ text last_accessed created_at user_id session_id "
-                            "SORTBY last_accessed ASC"  # Oldest first
-                        )
+                        if filters:
+                            # Combine hash query with filters using boolean AND
+                            query_expr = f"(@memory_hash:{{{memory_hash}}}) ({' '.join(filters)})"
+                        else:
+                            query_expr = f"@memory_hash:{{{memory_hash}}}"
 
                         search_results = await redis_client.execute_command(
-                            search_query
+                            "FT.SEARCH",
+                            index_name,
+                            f"'{query_expr}'",
+                            "RETURN",
+                            "6",
+                            "id_",
+                            "text",
+                            "last_accessed",
+                            "created_at",
+                            "user_id",
+                            "session_id",
+                            "SORTBY",
+                            "last_accessed",
+                            "ASC",
                         )
 
                         if search_results and search_results[0] > 1:
@@ -1209,14 +1218,23 @@ async def deduplicate_by_hash(
 
     # Use FT.SEARCH to find memories with this hash
     # TODO: Use RedisVL
-    search_query = (
-        f"FT.SEARCH {index_name} "
-        f"(@memory_hash:{{{memory_hash}}}) {filter_str} "
-        "RETURN 1 id_ "
-        "SORTBY last_accessed DESC"  # Newest first
-    )
+    if filter_str:
+        # Combine hash query with filters using boolean AND
+        query_expr = f"(@memory_hash:{{{memory_hash}}}) ({filter_str})"
+    else:
+        query_expr = f"@memory_hash:{{{memory_hash}}}"
 
-    search_results = await redis_client.execute_command(search_query)
+    search_results = await redis_client.execute_command(
+        "FT.SEARCH",
+        index_name,
+        f"'{query_expr}'",
+        "RETURN",
+        "1",
+        "id_",
+        "SORTBY",
+        "last_accessed",
+        "DESC",
+    )
 
     if search_results and search_results[0] > 0:
         # Found existing memory with the same hash
@@ -1285,14 +1303,24 @@ async def deduplicate_by_id(
 
     # Use FT.SEARCH to find memories with this id
     # TODO: Use RedisVL
-    search_query = (
-        f"FT.SEARCH {index_name} "
-        f"(@id:{{{memory.id}}}) {filter_str} "
-        "RETURN 2 id_ persisted_at "
-        "SORTBY last_accessed DESC"  # Newest first
-    )
+    if filter_str:
+        # Combine the id query with filters - Redis FT.SEARCH uses implicit AND between terms
+        query_expr = f"@id:{{{memory.id}}} {filter_str}"
+    else:
+        query_expr = f"@id:{{{memory.id}}}"
 
-    search_results = await redis_client.execute_command(search_query)
+    search_results = await redis_client.execute_command(
+        "FT.SEARCH",
+        index_name,
+        f"'{query_expr}'",
+        "RETURN",
+        "2",
+        "id_",
+        "persisted_at",
+        "SORTBY",
+        "last_accessed",
+        "DESC",
+    )
 
     if search_results and search_results[0] > 0:
         # Found existing memory with the same id

--- a/agent_memory_server/mcp.py
+++ b/agent_memory_server/mcp.py
@@ -562,6 +562,7 @@ async def memory_prompt(
         session = WorkingMemoryRequest(
             session_id=_session_id,
             namespace=namespace.eq if namespace and namespace.eq else None,
+            user_id=user_id.eq if user_id and user_id.eq else None,
             window_size=window_size,
             model_name=model_name,
             context_window_max=context_window_max,

--- a/agent_memory_server/models.py
+++ b/agent_memory_server/models.py
@@ -216,6 +216,7 @@ class WorkingMemoryRequest(BaseModel):
 
     session_id: str
     namespace: str | None = None
+    user_id: str | None = None
     window_size: int = settings.window_size
     model_name: ModelNameLiteral | None = None
     context_window_max: int | None = None
@@ -257,6 +258,7 @@ class GetSessionsQuery(BaseModel):
     limit: int = Field(default=20, ge=1, le=100)
     offset: int = Field(default=0, ge=0)
     namespace: str | None = None
+    user_id: str | None = None
 
 
 class HealthCheckResponse(BaseModel):

--- a/agent_memory_server/utils/keys.py
+++ b/agent_memory_server/utils/keys.py
@@ -56,13 +56,22 @@ class Keys:
         )
 
     @staticmethod
-    def working_memory_key(session_id: str, namespace: str | None = None) -> str:
+    def working_memory_key(
+        session_id: str, user_id: str | None = None, namespace: str | None = None
+    ) -> str:
         """Get the working memory key for a session."""
-        return (
-            f"working_memory:{namespace}:{session_id}"
-            if namespace
-            else f"working_memory:{session_id}"
-        )
+        # Build key components, filtering out None values
+        key_parts = ["working_memory"]
+
+        if namespace:
+            key_parts.append(namespace)
+
+        if user_id:
+            key_parts.append(user_id)
+
+        key_parts.append(session_id)
+
+        return ":".join(key_parts)
 
     @staticmethod
     def search_index_name() -> str:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,19 +22,25 @@ uv sync
 
 ## Running
 
-The easiest way to start the REST and MCP servers is to use Docker Compose. See the Docker Compose section below for more details.
+The easiest way to start the worker, REST API server, and MCP server is to use Docker Compose. See the Docker Compose section below for more details.
 
-But you can also run these servers via the CLI commands. Here's how you
+But you can also run these components via the CLI commands. Here's how you
 run the REST API server:
 
 ```bash
 uv run agent-memory api
 ```
 
-And the MCP server:
+Or the MCP server:
 
 ```bash
 uv run agent-memory mcp --mode <stdio|sse>
+```
+
+Both servers require a worker to be running, which you can start like this:
+
+```bash
+uv run agent-memory task-worker
 ```
 
 **NOTE:** With uv, prefix the command with `uv`, e.g.: `uv run agent-memory --mode sse`. If you installed from source, you'll probably need to add `--directory` to tell uv where to find the code: `uv run --directory <path/to/checkout> run agent-memory --mode stdio`.

--- a/docs/memory-types.md
+++ b/docs/memory-types.md
@@ -356,9 +356,6 @@ LONG_TERM_MEMORY=true            # Enable long-term memory features
 # Long-term memory settings
 ENABLE_DISCRETE_MEMORY_EXTRACTION=true  # Extract memories from messages
 GENERATION_MODEL=gpt-4o-mini     # Model for summarization/extraction
-
-# Search settings
-DEFAULT_MEMORY_LIMIT=1000        # Default search result limit
 ```
 
 For complete configuration options, see the [Configuration Guide](configuration.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,14 @@ quote-style = "double"
 # Use spaces for indentation
 indent-style = "space"
 
+[tool.uv.sources]
+agent-memory-client = { path = "agent-memory-client" }
+
+[project.optional-dependencies]
+dev = [
+  "agent-memory-client"
+]
+
 [dependency-groups]
 dev = [
     "pytest>=8.3.5",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -275,11 +275,11 @@ def redis_url(redis_container):
 
 
 @pytest.fixture()
-def async_redis_client(redis_url):
+def async_redis_client(use_test_redis_connection):
     """
-    An async Redis client that uses the dynamic `redis_url`.
+    An async Redis client that uses the same connection as other test fixtures.
     """
-    return AsyncRedis.from_url(redis_url)
+    return use_test_redis_connection
 
 
 @pytest.fixture()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -82,7 +82,7 @@ class TestMemoryEndpoints:
         session_id = session
 
         response = await client.get(
-            f"/v1/working-memory/{session_id}?namespace=test-namespace"
+            f"/v1/working-memory/{session_id}?namespace=test-namespace&user_id=test-user"
         )
 
         assert response.status_code == 200
@@ -288,7 +288,7 @@ class TestMemoryEndpoints:
         session_id = session
 
         response = await client.get(
-            f"/v1/working-memory/{session_id}?namespace=test-namespace"
+            f"/v1/working-memory/{session_id}?namespace=test-namespace&user_id=test-user"
         )
 
         assert response.status_code == 200
@@ -297,7 +297,7 @@ class TestMemoryEndpoints:
         assert len(data["messages"]) == 2
 
         response = await client.delete(
-            f"/v1/working-memory/{session_id}?namespace=test-namespace"
+            f"/v1/working-memory/{session_id}?namespace=test-namespace&user_id=test-user"
         )
 
         assert response.status_code == 200
@@ -307,7 +307,7 @@ class TestMemoryEndpoints:
         assert data["status"] == "ok"
 
         response = await client.get(
-            f"/v1/working-memory/{session_id}?namespace=test-namespace"
+            f"/v1/working-memory/{session_id}?namespace=test-namespace&user_id=test-user"
         )
         assert response.status_code == 200
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -229,11 +229,11 @@ class TestTaskWorker:
 
     @patch("docket.Worker.run")
     @patch("agent_memory_server.cli.settings")
-    def test_task_worker_success(self, mock_settings, mock_worker_run):
+    def test_task_worker_success(self, mock_settings, mock_worker_run, redis_url):
         """Test successful task worker start."""
         mock_settings.use_docket = True
         mock_settings.docket_name = "test-docket"
-        mock_settings.redis_url = "redis://localhost:6379/0"
+        mock_settings.redis_url = redis_url
 
         mock_worker_run.return_value = None
 
@@ -258,11 +258,13 @@ class TestTaskWorker:
 
     @patch("docket.Worker.run")
     @patch("agent_memory_server.cli.settings")
-    def test_task_worker_default_params(self, mock_settings, mock_worker_run):
+    def test_task_worker_default_params(
+        self, mock_settings, mock_worker_run, redis_url
+    ):
         """Test task worker with default parameters."""
         mock_settings.use_docket = True
         mock_settings.docket_name = "test-docket"
-        mock_settings.redis_url = "redis://localhost:6379/0"
+        mock_settings.redis_url = redis_url
 
         mock_worker_run.return_value = None
 

--- a/tests/test_client_enhancements.py
+++ b/tests/test_client_enhancements.py
@@ -533,8 +533,8 @@ class TestEnhancedConvenienceMethods:
         )
 
         new_messages = [
-            MemoryMessage(role="assistant", content="Second message"),
-            MemoryMessage(role="user", content="Third message"),
+            {"role": "assistant", "content": "Second message"},
+            {"role": "user", "content": "Third message"},
         ]
 
         with (

--- a/tests/test_client_enhancements.py
+++ b/tests/test_client_enhancements.py
@@ -4,20 +4,19 @@ from unittest.mock import patch
 
 import pytest
 from agent_memory_client import MemoryAPIClient, MemoryClientConfig
-from fastapi import FastAPI
-from httpx import ASGITransport, AsyncClient
-
-from agent_memory_server.api import router as memory_router
-from agent_memory_server.healthcheck import router as health_router
-from agent_memory_server.models import (
+from agent_memory_client.models import (
     AckResponse,
     ClientMemoryRecord,
-    MemoryMessage,
     MemoryRecordResult,
     MemoryRecordResults,
     MemoryTypeEnum,
     WorkingMemoryResponse,
 )
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from agent_memory_server.api import router as memory_router
+from agent_memory_server.healthcheck import router as health_router
 
 
 @pytest.fixture
@@ -520,7 +519,7 @@ class TestEnhancedConvenienceMethods:
         session_id = "test-session"
 
         existing_messages = [
-            MemoryMessage(role="user", content="First message"),
+            {"role": "user", "content": "First message"},
         ]
 
         existing_memory = WorkingMemoryResponse(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -102,6 +102,7 @@ class TestMCP:
                     "query": "Test query",
                     "session_id": {"eq": session},
                     "namespace": {"eq": "test-namespace"},
+                    "user_id": {"eq": "test-user"},
                 },
             )
             assert isinstance(prompt, CallToolResult)

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,28 @@ wheels = [
 ]
 
 [[package]]
+name = "agent-memory-client"
+source = { directory = "agent-memory-client" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-ulid" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.25.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
+    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.21.0" },
+    { name = "python-ulid", specifier = ">=3.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+]
+
+[[package]]
 name = "agent-memory-server"
 source = { editable = "." }
 dependencies = [
@@ -50,6 +72,11 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "agent-memory-client" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "freezegun" },
@@ -66,6 +93,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", specifier = ">=1.6.0" },
+    { name = "agent-memory-client", marker = "extra == 'dev'", directory = "agent-memory-client" },
     { name = "anthropic", specifier = ">=0.15.0" },
     { name = "bertopic", specifier = ">=0.16.4,<0.17.0" },
     { name = "click", specifier = ">=8.1.0" },


### PR DESCRIPTION
A multi-user environment requires supporting user IDs for every operation. It should be optional, so the server continues to work for single-user environments.

NOTE: Significant AI slop in this one, still tweaking it.